### PR TITLE
feat: add troll detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 VITE_SUPABASE_URL=your_supabase_project_url
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+# OpenAI API key for troll detection and incident validation
+VITE_OPENAI_API_KEY=your_openai_api_key


### PR DESCRIPTION
## Summary
- check new incident text with OpenAI moderation before saving
- validate name and notes with OpenAI prompt to ensure relevance
- document required OpenAI API key for moderation and validation in example env

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6895aff2b92083279b4d530ee131e398