### PR TITLE
Add routing and interactive card hovers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
         "react-chartjs-2": "^5.3.0",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.8.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -1976,6 +1977,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3436,6 +3446,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.1.tgz",
+      "integrity": "sha512-5cy/M8DHcG51/KUIka1nfZ2QeylS4PJRs6TT8I4PF5axVsI5JUxp0hC0NZ/AEEj8Vw7xsEoD7L/6FY+zoYaOGA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.1.tgz",
+      "integrity": "sha512-NkgBCF3sVgCiAWIlSt89GR2PLaksMpoo3HDCorpRfnCEfdtRPLiuTf+CNXvqZMI5SJLZCLpVCvcZrTdtGW64xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3567,6 +3615,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.3.0",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { AddIncidentForm } from './components/AddIncidentForm';
 import { IncidentCard } from './components/IncidentCard';
 import { StatsCard } from './components/StatsCard';
 import { StatsPage } from './components/StatsPage';
+import { Routes, Route } from 'react-router-dom';
 
 export interface CakeIncident {
   id: string;
@@ -20,7 +21,6 @@ function App() {
   const [incidents, setIncidents] = useState<CakeIncident[]>([]);
   const [loading, setLoading] = useState(true);
   const [showAddForm, setShowAddForm] = useState(false);
-  const [currentPage, setCurrentPage] = useState<'home' | 'stats'>('home');
 
   useEffect(() => {
     fetchIncidents();
@@ -71,8 +71,8 @@ function App() {
         .eq('id', id);
 
       if (error) throw error;
-      
-      setIncidents(incidents.map(incident => 
+
+      setIncidents(incidents.map(incident =>
         incident.id === id ? { ...incident, cake_delivered: delivered } : incident
       ));
     } catch (error) {
@@ -84,7 +84,6 @@ function App() {
   const totalOwed = incidents.filter(i => !i.cake_delivered).length;
   const totalDelivered = incidents.filter(i => i.cake_delivered).length;
 
-  // Group incidents by person for leaderboard
   const leaderboard = incidents.reduce((acc, incident) => {
     const name = incident.person_name;
     if (!acc[name]) {
@@ -100,8 +99,149 @@ function App() {
   }, {} as Record<string, { total: number; owed: number; delivered: number }>);
 
   const leaderboardEntries = Object.entries(leaderboard)
-    .sort(([,a], [,b]) => b.owed - a.owed)
+    .sort(([, a], [, b]) => b.owed - a.owed)
     .slice(0, 5);
+
+  const HomePage = () => (
+    <>
+      {/* Header */}
+      <div className="text-center mb-12">
+        <div className="flex items-center justify-center mb-4">
+          <Cake className="h-12 w-12 text-amber-600 mr-3" />
+          <h1 className="text-5xl font-bold text-gray-800">Office Cake Tracker</h1>
+        </div>
+        <p className="text-xl text-gray-600 max-w-2xl mx-auto">
+          Keep track of who owes cake for forgetting to lock their computer! 🍰
+        </p>
+      </div>
+
+      {/* Stats Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
+        <StatsCard
+          title="Total Incidents"
+          value={totalIncidents}
+          icon={<TrendingUp className="h-6 w-6" />}
+          color="bg-blue-500"
+        />
+        <StatsCard
+          title="Cakes Owed"
+          value={totalOwed}
+          icon={<Clock className="h-6 w-6" />}
+          color="bg-red-500"
+        />
+        <StatsCard
+          title="Cakes Delivered"
+          value={totalDelivered}
+          icon={<CheckCircle className="h-6 w-6" />}
+          color="bg-green-500"
+        />
+        <StatsCard
+          title="Active Debtors"
+          value={leaderboardEntries.filter(([, stats]) => stats.owed > 0).length}
+          icon={<Users className="h-6 w-6" />}
+          color="bg-purple-500"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-8">
+        {/* Main Content */}
+        <div className="xl:col-span-2">
+          {/* Add New Incident Button */}
+          <div className="mb-8">
+            <button
+              onClick={() => setShowAddForm(true)}
+              className="bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-600 hover:to-orange-600 text-white px-8 py-4 rounded-xl font-semibold text-lg shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-200 flex items-center gap-3"
+            >
+              <Plus className="h-6 w-6" />
+              Report New Incident
+            </button>
+          </div>
+
+          {/* Recent Incidents */}
+          <div className="bg-white rounded-2xl shadow-xl p-8">
+            <h2 className="text-2xl font-bold text-gray-800 mb-6 flex items-center gap-3">
+              <Clock className="h-6 w-6 text-amber-600" />
+              Recent Incidents
+            </h2>
+
+            {incidents.length === 0 ? (
+              <div className="text-center py-12">
+                <Cake className="h-16 w-16 text-gray-300 mx-auto mb-4" />
+                <p className="text-gray-500 text-lg">No incidents recorded yet!</p>
+                <p className="text-gray-400">Click "Report New Incident" to get started.</p>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {incidents.slice(0, 10).map((incident) => (
+                  <IncidentCard
+                    key={incident.id}
+                    incident={incident}
+                    onToggleDelivered={toggleCakeDelivered}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-8">
+          {/* Leaderboard */}
+          <div className="bg-white rounded-2xl shadow-xl p-8">
+            <h2 className="text-2xl font-bold text-gray-800 mb-6 flex items-center gap-3">
+              <TrendingUp className="h-6 w-6 text-red-500" />
+              Cake Debt Leaderboard
+            </h2>
+
+            {leaderboardEntries.length === 0 ? (
+              <p className="text-gray-500 text-center py-8">No data yet!</p>
+            ) : (
+              <div className="space-y-4">
+                {leaderboardEntries.map(([name, stats], index) => (
+                  <div
+                    key={name}
+                    className={`flex items-center justify-between p-4 rounded-xl border-2 transition-transform duration-200 hover:shadow-md hover:scale-105 ${
+                      stats.owed > 0 ? 'border-red-200 bg-red-50' : 'border-green-200 bg-green-50'
+                    }`}
+                  >
+                    <div className="flex items-center gap-3">
+                      <div
+                        className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
+                          index === 0
+                            ? 'bg-yellow-400 text-yellow-900'
+                            : index === 1
+                            ? 'bg-gray-400 text-gray-900'
+                            : index === 2
+                            ? 'bg-amber-600 text-amber-100'
+                            : 'bg-gray-200 text-gray-700'
+                        }`}
+                      >
+                        {index + 1}
+                      </div>
+                      <div>
+                        <p className="font-semibold text-gray-800">{name}</p>
+                        <p className="text-sm text-gray-600">
+                          {stats.total} total incident{stats.total !== 1 ? 's' : ''}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="text-right">
+                      <p className={`font-bold ${stats.owed > 0 ? 'text-red-600' : 'text-green-600'}`}>
+                        {stats.owed > 0 ? `${stats.owed} owed` : 'All delivered!'}
+                      </p>
+                      {stats.delivered > 0 && (
+                        <p className="text-sm text-green-600">{stats.delivered} delivered</p>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
 
   if (loading) {
     return (
@@ -114,150 +254,13 @@ function App() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-pink-50">
       <div className="container mx-auto px-4 py-8 max-w-7xl">
-        {/* Navigation */}
-        <Navigation currentPage={currentPage} onPageChange={setCurrentPage} />
+        <Navigation />
 
-        {currentPage === 'home' ? (
-          <>
-            {/* Header */}
-            <div className="text-center mb-12">
-              <div className="flex items-center justify-center mb-4">
-                <Cake className="h-12 w-12 text-amber-600 mr-3" />
-                <h1 className="text-5xl font-bold text-gray-800">Office Cake Tracker</h1>
-              </div>
-              <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-                Keep track of who owes cake for forgetting to lock their computer! 🍰
-              </p>
-            </div>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/stats" element={<StatsPage incidents={incidents} />} />
+        </Routes>
 
-            {/* Stats Cards */}
-            <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
-              <StatsCard
-                title="Total Incidents"
-                value={totalIncidents}
-                icon={<TrendingUp className="h-6 w-6" />}
-                color="bg-blue-500"
-              />
-              <StatsCard
-                title="Cakes Owed"
-                value={totalOwed}
-                icon={<Clock className="h-6 w-6" />}
-                color="bg-red-500"
-              />
-              <StatsCard
-                title="Cakes Delivered"
-                value={totalDelivered}
-                icon={<CheckCircle className="h-6 w-6" />}
-                color="bg-green-500"
-              />
-              <StatsCard
-                title="Active Debtors"
-                value={leaderboardEntries.filter(([,stats]) => stats.owed > 0).length}
-                icon={<Users className="h-6 w-6" />}
-                color="bg-purple-500"
-              />
-            </div>
-
-            <div className="grid grid-cols-1 xl:grid-cols-3 gap-8">
-              {/* Main Content */}
-              <div className="xl:col-span-2">
-                {/* Add New Incident Button */}
-                <div className="mb-8">
-                  <button
-                    onClick={() => setShowAddForm(true)}
-                    className="bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-600 hover:to-orange-600 text-white px-8 py-4 rounded-xl font-semibold text-lg shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-200 flex items-center gap-3"
-                  >
-                    <Plus className="h-6 w-6" />
-                    Report New Incident
-                  </button>
-                </div>
-
-                {/* Recent Incidents */}
-                <div className="bg-white rounded-2xl shadow-xl p-8">
-                  <h2 className="text-2xl font-bold text-gray-800 mb-6 flex items-center gap-3">
-                    <Clock className="h-6 w-6 text-amber-600" />
-                    Recent Incidents
-                  </h2>
-                  
-                  {incidents.length === 0 ? (
-                    <div className="text-center py-12">
-                      <Cake className="h-16 w-16 text-gray-300 mx-auto mb-4" />
-                      <p className="text-gray-500 text-lg">No incidents recorded yet!</p>
-                      <p className="text-gray-400">Click "Report New Incident" to get started.</p>
-                    </div>
-                  ) : (
-                    <div className="space-y-4">
-                      {incidents.slice(0, 10).map((incident) => (
-                        <IncidentCard
-                          key={incident.id}
-                          incident={incident}
-                          onToggleDelivered={toggleCakeDelivered}
-                        />
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {/* Sidebar */}
-              <div className="space-y-8">
-                {/* Leaderboard */}
-                <div className="bg-white rounded-2xl shadow-xl p-8">
-                  <h2 className="text-2xl font-bold text-gray-800 mb-6 flex items-center gap-3">
-                    <TrendingUp className="h-6 w-6 text-red-500" />
-                    Cake Debt Leaderboard
-                  </h2>
-                  
-                  {leaderboardEntries.length === 0 ? (
-                    <p className="text-gray-500 text-center py-8">No data yet!</p>
-                  ) : (
-                    <div className="space-y-4">
-                      {leaderboardEntries.map(([name, stats], index) => (
-                        <div
-                          key={name}
-                          className={`flex items-center justify-between p-4 rounded-xl border-2 ${
-                            stats.owed > 0 
-                              ? 'border-red-200 bg-red-50' 
-                              : 'border-green-200 bg-green-50'
-                          }`}
-                        >
-                          <div className="flex items-center gap-3">
-                            <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
-                              index === 0 ? 'bg-yellow-400 text-yellow-900' :
-                              index === 1 ? 'bg-gray-400 text-gray-900' :
-                              index === 2 ? 'bg-amber-600 text-amber-100' :
-                              'bg-gray-200 text-gray-700'
-                            }`}>
-                              {index + 1}
-                            </div>
-                            <div>
-                              <p className="font-semibold text-gray-800">{name}</p>
-                              <p className="text-sm text-gray-600">
-                                {stats.total} total incident{stats.total !== 1 ? 's' : ''}
-                              </p>
-                            </div>
-                          </div>
-                          <div className="text-right">
-                            <p className={`font-bold ${stats.owed > 0 ? 'text-red-600' : 'text-green-600'}`}>
-                              {stats.owed > 0 ? `${stats.owed} owed` : 'All delivered!'}  
-                            </p>
-                            {stats.delivered > 0 && (
-                              <p className="text-sm text-green-600">{stats.delivered} delivered</p>
-                            )}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          </>
-        ) : (
-          <StatsPage incidents={incidents} />
-        )}
-
-        {/* Add Incident Modal */}
         {showAddForm && (
           <AddIncidentForm
             onAdd={addIncident}
@@ -271,7 +274,3 @@ function App() {
 
 export default App;
 
-        /*  </div>
-          <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-            Keep track of who owes cake for forgetting to lock their computer! 🍰
-          </p>*/

--- a/src/components/IncidentCard.tsx
+++ b/src/components/IncidentCard.tsx
@@ -28,9 +28,9 @@ export const IncidentCard: React.FC<IncidentCardProps> = ({ incident, onToggleDe
   };
 
   return (
-    <div className={`p-6 rounded-xl border-2 transition-all duration-200 hover:shadow-md ${
-      incident.cake_delivered 
-        ? 'border-green-200 bg-green-50' 
+    <div className={`p-6 rounded-xl border-2 transition-all duration-200 hover:shadow-md hover:scale-105 ${
+      incident.cake_delivered
+        ? 'border-green-200 bg-green-50'
         : 'border-red-200 bg-red-50'
     }`}>
       <div className="flex items-start justify-between">

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,37 +1,40 @@
 import React from 'react';
+import { NavLink } from 'react-router-dom';
 import { BarChart3, Home } from 'lucide-react';
 
-interface NavigationProps {
-  currentPage: 'home' | 'stats';
-  onPageChange: (page: 'home' | 'stats') => void;
-}
+export const Navigation: React.FC = () => {
+  const baseClass =
+    'flex items-center gap-2 px-6 py-3 rounded-xl font-semibold transition-all duration-200';
 
-export const Navigation: React.FC<NavigationProps> = ({ currentPage, onPageChange }) => {
   return (
     <nav className="bg-white rounded-2xl shadow-lg p-2 mb-8">
       <div className="flex gap-2">
-        <button
-          onClick={() => onPageChange('home')}
-          className={`flex items-center gap-2 px-6 py-3 rounded-xl font-semibold transition-all duration-200 ${
-            currentPage === 'home'
-              ? 'bg-gradient-to-r from-amber-500 to-orange-500 text-white shadow-md'
-              : 'text-gray-600 hover:bg-gray-100'
-          }`}
+        <NavLink
+          to="/"
+          className={({ isActive }) =>
+            `${baseClass} ${
+              isActive
+                ? 'bg-gradient-to-r from-amber-500 to-orange-500 text-white shadow-md'
+                : 'text-gray-600 hover:bg-gray-100'
+            }`
+          }
         >
           <Home className="h-5 w-5" />
           Dashboard
-        </button>
-        <button
-          onClick={() => onPageChange('stats')}
-          className={`flex items-center gap-2 px-6 py-3 rounded-xl font-semibold transition-all duration-200 ${
-            currentPage === 'stats'
-              ? 'bg-gradient-to-r from-amber-500 to-orange-500 text-white shadow-md'
-              : 'text-gray-600 hover:bg-gray-100'
-          }`}
+        </NavLink>
+        <NavLink
+          to="/stats"
+          className={({ isActive }) =>
+            `${baseClass} ${
+              isActive
+                ? 'bg-gradient-to-r from-amber-500 to-orange-500 text-white shadow-md'
+                : 'text-gray-600 hover:bg-gray-100'
+            }`
+          }
         >
           <BarChart3 className="h-5 w-5" />
           Statistics
-        </button>
+        </NavLink>
       </div>
     </nav>
   );

--- a/src/components/StatsPage.tsx
+++ b/src/components/StatsPage.tsx
@@ -291,23 +291,23 @@ export const StatsPage: React.FC<StatsPageProps> = ({ incidents }) => {
 
       {/* Summary Stats */}
       <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
-        <div className="bg-white rounded-2xl shadow-lg p-6 text-center">
+        <div className="bg-white rounded-2xl shadow-lg p-6 text-center transition-transform duration-200 hover:shadow-xl hover:scale-105">
           <div className="text-3xl font-bold text-blue-600">{totalIncidents}</div>
           <div className="text-sm text-gray-600 mt-1">Total Incidents</div>
         </div>
-        <div className="bg-white rounded-2xl shadow-lg p-6 text-center">
+        <div className="bg-white rounded-2xl shadow-lg p-6 text-center transition-transform duration-200 hover:shadow-xl hover:scale-105">
           <div className="text-3xl font-bold text-green-600">{totalDelivered}</div>
           <div className="text-sm text-gray-600 mt-1">Cakes Delivered</div>
         </div>
-        <div className="bg-white rounded-2xl shadow-lg p-6 text-center">
+        <div className="bg-white rounded-2xl shadow-lg p-6 text-center transition-transform duration-200 hover:shadow-xl hover:scale-105">
           <div className="text-3xl font-bold text-red-600">{totalOwed}</div>
           <div className="text-sm text-gray-600 mt-1">Cakes Owed</div>
         </div>
-        <div className="bg-white rounded-2xl shadow-lg p-6 text-center">
+        <div className="bg-white rounded-2xl shadow-lg p-6 text-center transition-transform duration-200 hover:shadow-xl hover:scale-105">
           <div className="text-3xl font-bold text-purple-600">{deliveryRate}%</div>
           <div className="text-sm text-gray-600 mt-1">Delivery Rate</div>
         </div>
-        <div className="bg-white rounded-2xl shadow-lg p-6 text-center">
+        <div className="bg-white rounded-2xl shadow-lg p-6 text-center transition-transform duration-200 hover:shadow-xl hover:scale-105">
           <div className="text-lg font-bold text-amber-600 truncate">
             {topDebtor ? topDebtor.name : 'N/A'}
           </div>
@@ -318,7 +318,7 @@ export const StatsPage: React.FC<StatsPageProps> = ({ incidents }) => {
       {/* Charts */}
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-8">
         {/* Bar Chart */}
-        <div className="bg-white rounded-2xl shadow-xl p-8">
+        <div className="bg-white rounded-2xl shadow-xl p-8 transition-transform duration-200 hover:shadow-2xl hover:scale-105">
           <div className="h-96">
             {personStats.length > 0 ? (
               <Bar data={barChartData} options={barChartOptions} />
@@ -335,7 +335,7 @@ export const StatsPage: React.FC<StatsPageProps> = ({ incidents }) => {
         </div>
 
         {/* Line Chart */}
-        <div className="bg-white rounded-2xl shadow-xl p-8">
+        <div className="bg-white rounded-2xl shadow-xl p-8 transition-transform duration-200 hover:shadow-2xl hover:scale-105">
           <div className="mb-4">
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-lg font-semibold text-gray-800 flex items-center gap-2">
@@ -371,7 +371,7 @@ export const StatsPage: React.FC<StatsPageProps> = ({ incidents }) => {
 
       {/* Detailed Leaderboard */}
       {personStats.length > 0 && (
-        <div className="bg-white rounded-2xl shadow-xl p-8">
+        <div className="bg-white rounded-2xl shadow-xl p-8 transition-transform duration-200 hover:shadow-2xl hover:scale-105">
           <h2 className="text-2xl font-bold text-gray-800 mb-6 flex items-center gap-3">
             <Award className="h-6 w-6 text-amber-600" />
             Detailed Leaderboard

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- integrate React Router for home and statistics pages
- convert nav buttons to links and display current page in URL
- add hover scale/shadow effects to incident and leaderboard cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a2ff4077608327938558a4ff894a92